### PR TITLE
Enabled full screen

### DIFF
--- a/bbb_buttons.js
+++ b/bbb_buttons.js
@@ -125,11 +125,17 @@ function load() {
 		btnToggleDarkMode.style.transitionDuration = TRANSITION_DURATION
 	}
 
+  function fullScreen() {
+		presentationArea.requestFullscreen();
+  }
+
 	function createButton(color, symbol, func, append=false){
 		let btn = document.createElement('button');
 		btn.type = "button";
 		btn.width = 100;
-		btn.height = 100;
+    btn.height = 100;
+    btn.style.marginLeft = "1.5px";
+	  btn.style.marginRight = "1.5px";
 		btn.style.background = color;
 		btn.innerText = symbol;
 		btn.onclick = func;
@@ -141,7 +147,8 @@ function load() {
 
 	var btn_div = document.createElement('div');
 	btn_div.id = "btn-div";
-	btn_div.style.display = "block";
+  btn_div.style.display = "block";
+  btn_div.style.textAlign = "center";
 	btn_div.appendChild(label);
 	createButton('gray', '←', back, true);
 	createButton('gray', '→', forward, true);
@@ -161,7 +168,13 @@ function load() {
 	var chat = document.getElementById("chat")
 	chat.style.border = "0px";
 	var chatAreaSecond = document.getElementsByClassName("inner-wrap").item(0)
-	var playBack = document.getElementById("main-section")
+  var playBack = document.getElementById("main-section")
+  
+  var presentationArea = document.getElementById("presentation-area");
+  var oldFullscreenButton = document.getElementsByClassName("acorn-fullscreen-button")[0];
+  var fullscreenButton = oldFullscreenButton.cloneNode(true);
+  oldFullscreenButton.parentNode.replaceChild(fullscreenButton, oldFullscreenButton);
+  fullscreenButton.addEventListener("click", fullScreen);
 
 	setTransitions()
 


### PR DESCRIPTION
The full screen button on BBB was making the camera area full screen, so I changed it to make the presentation area full screen instead of the camera area.
I also centered the buttons menu, and added a gap in-between, so now it looks like this:
![image](https://user-images.githubusercontent.com/49248144/99682830-f5eb8c00-2a7f-11eb-995c-c040cb15f965.png)
